### PR TITLE
Add design system page with Banner component showcase

### DIFF
--- a/src/app/(main)/dashboard/_components/sidebar/nav-main.tsx
+++ b/src/app/(main)/dashboard/_components/sidebar/nav-main.tsx
@@ -66,7 +66,6 @@ const NavItemExpanded = ({
               <Link href={item.url} target={item.newTab ? "_blank" : undefined}>
                 {item.icon && <item.icon />}
                 <span>{item.title}</span>
-                {item.comingSoon && <IsComingSoon />}
               </Link>
             </SidebarMenuButton>
           )}

--- a/src/app/(main)/dashboard/_components/sidebar/nav-main.tsx
+++ b/src/app/(main)/dashboard/_components/sidebar/nav-main.tsx
@@ -98,6 +98,26 @@ const NavItemCollapsed = ({
   item: NavMainItem;
   isActive: (url: string, subItems?: NavMainItem["subItems"]) => boolean;
 }) => {
+  // If item has no subItems, render as a direct link
+  if (!item.subItems || item.subItems.length === 0) {
+    return (
+      <SidebarMenuItem key={item.title}>
+        <SidebarMenuButton
+          asChild
+          disabled={item.comingSoon}
+          tooltip={item.title}
+          isActive={isActive(item.url)}
+        >
+          <Link href={item.url} target={item.newTab ? "_blank" : undefined}>
+            {item.icon && <item.icon />}
+            <span>{item.title}</span>
+          </Link>
+        </SidebarMenuButton>
+      </SidebarMenuItem>
+    );
+  }
+
+  // If item has subItems, render as dropdown
   return (
     <SidebarMenuItem key={item.title}>
       <DropdownMenu>

--- a/src/app/(main)/dashboard/_components/sidebar/nav-main.tsx
+++ b/src/app/(main)/dashboard/_components/sidebar/nav-main.tsx
@@ -54,7 +54,6 @@ const NavItemExpanded = ({
             >
               {item.icon && <item.icon />}
               <span>{item.title}</span>
-              {item.comingSoon && <IsComingSoon />}
               <ChevronRight className="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
             </SidebarMenuButton>
           ) : (

--- a/src/app/(main)/dashboard/_components/sidebar/nav-main.tsx
+++ b/src/app/(main)/dashboard/_components/sidebar/nav-main.tsx
@@ -31,9 +31,7 @@ interface NavMainProps {
   readonly items: readonly NavGroup[];
 }
 
-const IsComingSoon = () => (
-  <span className="ml-auto rounded-md bg-gray-200 px-2 py-1 text-xs dark:text-gray-800">Soon</span>
-);
+
 
 const NavItemExpanded = ({
   item,

--- a/src/app/(main)/dashboard/_components/sidebar/nav-main.tsx
+++ b/src/app/(main)/dashboard/_components/sidebar/nav-main.tsx
@@ -79,7 +79,6 @@ const NavItemExpanded = ({
                     <Link href={subItem.url} target={subItem.newTab ? "_blank" : undefined}>
                       {subItem.icon && <subItem.icon />}
                       <span>{subItem.title}</span>
-                      {subItem.comingSoon && <IsComingSoon />}
                     </Link>
                   </SidebarMenuSubButton>
                 </SidebarMenuSubItem>

--- a/src/app/(main)/dashboard/_components/sidebar/nav-main.tsx
+++ b/src/app/(main)/dashboard/_components/sidebar/nav-main.tsx
@@ -125,7 +125,6 @@ const NavItemCollapsed = ({
                 <Link href={subItem.url} target={subItem.newTab ? "_blank" : undefined}>
                   {subItem.icon && <subItem.icon className="[&>svg]:text-sidebar-foreground" />}
                   <span>{subItem.title}</span>
-                  {subItem.comingSoon && <IsComingSoon />}
                 </Link>
               </SidebarMenuSubButton>
             </DropdownMenuItem>

--- a/src/app/(main)/dashboard/calendar/page.tsx
+++ b/src/app/(main)/dashboard/calendar/page.tsx
@@ -187,33 +187,39 @@ const BookingDialog = () => {
             </div>
           </div>
 
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
-            <div className="space-y-2">
-              <Label>Date *</Label>
-              <div className="border rounded-md p-2">
-                <Calendar
-                  mode="single"
-                  selected={formData.date}
-                  onSelect={(date) => setFormData({ ...formData, date })}
-                  disabled={(date) => date < new Date()}
-                  className="w-full"
-                />
+          <div className="space-y-6">
+            <div className="flex gap-5 max-md:flex-col max-md:gap-0">
+              <div className="flex flex-col w-1/2 max-md:w-full max-md:ml-0">
+                <div className="space-y-2">
+                  <Label>Date *</Label>
+                  <div className="border rounded-md p-2">
+                    <Calendar
+                      mode="single"
+                      selected={formData.date}
+                      onSelect={(date) => setFormData({ ...formData, date })}
+                      disabled={(date) => date < new Date()}
+                      className="w-full"
+                    />
+                  </div>
+                </div>
               </div>
-            </div>
-            <div className="space-y-2">
-              <Label>Time *</Label>
-              <Select onValueChange={(value) => setFormData({ ...formData, time: value })}>
-                <SelectTrigger>
-                  <SelectValue placeholder="Select time" />
-                </SelectTrigger>
-                <SelectContent>
-                  {timeSlots.map((time) => (
-                    <SelectItem key={time} value={time}>
-                      {time}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <div className="flex flex-col w-1/2 ml-5 max-md:w-full max-md:ml-0">
+                <div className="space-y-2">
+                  <Label>Time *</Label>
+                  <Select onValueChange={(value) => setFormData({ ...formData, time: value })}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Select time" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {timeSlots.map((time) => (
+                        <SelectItem key={time} value={time}>
+                          {time}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
             </div>
             <div className="space-y-2">
               <Label>Duration *</Label>

--- a/src/app/(main)/dashboard/calendar/page.tsx
+++ b/src/app/(main)/dashboard/calendar/page.tsx
@@ -1,0 +1,397 @@
+"use client";
+
+import { useState } from "react";
+import { CalendarIcon, Clock, MapPin, Users, Plus } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+
+// Mock events data
+const mockEvents = [
+  {
+    id: 1,
+    title: "Team Standup",
+    time: "9:00 AM",
+    duration: "30 min",
+    type: "meeting",
+    attendees: 5,
+    location: "Conference Room A",
+  },
+  {
+    id: 2,
+    title: "Project Review",
+    time: "2:00 PM",
+    duration: "1 hour",
+    type: "review",
+    attendees: 8,
+    location: "Main Hall",
+  },
+  {
+    id: 3,
+    title: "Client Call",
+    time: "4:00 PM",
+    duration: "45 min",
+    type: "call",
+    attendees: 3,
+    location: "Virtual",
+  },
+];
+
+const timeSlots = [
+  "9:00 AM",
+  "9:30 AM",
+  "10:00 AM",
+  "10:30 AM",
+  "11:00 AM",
+  "11:30 AM",
+  "12:00 PM",
+  "12:30 PM",
+  "1:00 PM",
+  "1:30 PM",
+  "2:00 PM",
+  "2:30 PM",
+  "3:00 PM",
+  "3:30 PM",
+  "4:00 PM",
+  "4:30 PM",
+  "5:00 PM",
+  "5:30 PM",
+];
+
+const durations = ["15 minutes", "30 minutes", "45 minutes", "1 hour", "1.5 hours", "2 hours"];
+
+const EventCard = ({ event }: { event: (typeof mockEvents)[0] }) => {
+  const getEventColor = (type: string) => {
+    switch (type) {
+      case "meeting":
+        return "bg-blue-100 border-blue-200 text-blue-800 dark:bg-blue-900 dark:border-blue-800 dark:text-blue-100";
+      case "review":
+        return "bg-green-100 border-green-200 text-green-800 dark:bg-green-900 dark:border-green-800 dark:text-green-100";
+      case "call":
+        return "bg-purple-100 border-purple-200 text-purple-800 dark:bg-purple-900 dark:border-purple-800 dark:text-purple-100";
+      default:
+        return "bg-gray-100 border-gray-200 text-gray-800 dark:bg-gray-900 dark:border-gray-800 dark:text-gray-100";
+    }
+  };
+
+  return (
+    <Card className={`transition-all hover:shadow-md ${getEventColor(event.type)}`}>
+      <CardContent className="p-4">
+        <div className="flex items-start justify-between">
+          <div className="space-y-2">
+            <h4 className="font-medium leading-none">{event.title}</h4>
+            <div className="flex items-center gap-4 text-sm opacity-80">
+              <div className="flex items-center gap-1">
+                <Clock className="size-3" />
+                <span>{event.time}</span>
+              </div>
+              <div className="flex items-center gap-1">
+                <Users className="size-3" />
+                <span>{event.attendees}</span>
+              </div>
+            </div>
+            <div className="flex items-center gap-1 text-sm opacity-80">
+              <MapPin className="size-3" />
+              <span>{event.location}</span>
+            </div>
+          </div>
+          <Badge variant="secondary" className="text-xs">
+            {event.duration}
+          </Badge>
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+const BookingDialog = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [formData, setFormData] = useState({
+    title: "",
+    date: undefined as Date | undefined,
+    time: "",
+    duration: "",
+    location: "",
+    attendees: "",
+    description: "",
+  });
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    console.log("Booking meeting:", formData);
+    // Here you would typically send the data to your backend
+    setIsOpen(false);
+    // Reset form
+    setFormData({
+      title: "",
+      date: undefined,
+      time: "",
+      duration: "",
+      location: "",
+      attendees: "",
+      description: "",
+    });
+  };
+
+  const isFormValid = formData.title && formData.date && formData.time && formData.duration;
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogTrigger asChild>
+        <Button className="gap-2">
+          <Plus className="size-4" />
+          Book a Meeting
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-[600px]">
+        <DialogHeader>
+          <DialogTitle>Book a Meeting</DialogTitle>
+          <DialogDescription>Schedule a new meeting by filling out the details below.</DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="title">Meeting Title *</Label>
+              <Input
+                id="title"
+                placeholder="Enter meeting title"
+                value={formData.title}
+                onChange={(e) => setFormData({ ...formData, title: e.target.value })}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="attendees">Attendees (Email)</Label>
+              <Input
+                id="attendees"
+                placeholder="Enter email addresses"
+                value={formData.attendees}
+                onChange={(e) => setFormData({ ...formData, attendees: e.target.value })}
+              />
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+            <div className="space-y-2">
+              <Label>Date *</Label>
+              <div className="border rounded-md p-2">
+                <Calendar
+                  mode="single"
+                  selected={formData.date}
+                  onSelect={(date) => setFormData({ ...formData, date })}
+                  disabled={(date) => date < new Date()}
+                  className="w-full"
+                />
+              </div>
+            </div>
+            <div className="space-y-2">
+              <Label>Time *</Label>
+              <Select onValueChange={(value) => setFormData({ ...formData, time: value })}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select time" />
+                </SelectTrigger>
+                <SelectContent>
+                  {timeSlots.map((time) => (
+                    <SelectItem key={time} value={time}>
+                      {time}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label>Duration *</Label>
+              <Select onValueChange={(value) => setFormData({ ...formData, duration: value })}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select duration" />
+                </SelectTrigger>
+                <SelectContent>
+                  {durations.map((duration) => (
+                    <SelectItem key={duration} value={duration}>
+                      {duration}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="location">Location</Label>
+            <Input
+              id="location"
+              placeholder="Conference room, virtual link, etc."
+              value={formData.location}
+              onChange={(e) => setFormData({ ...formData, location: e.target.value })}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="description">Description</Label>
+            <Textarea
+              id="description"
+              placeholder="Meeting agenda, notes, etc."
+              rows={3}
+              value={formData.description}
+              onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+            />
+          </div>
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setIsOpen(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!isFormValid}>
+              Book Meeting
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default function CalendarPage() {
+  const [selectedDate, setSelectedDate] = useState<Date | undefined>(new Date());
+
+  return (
+    <div className="@container/main flex flex-col gap-6 md:gap-8">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="space-y-1">
+          <h1 className="text-3xl font-bold tracking-tight">Calendar</h1>
+          <p className="text-muted-foreground">Manage your schedule and book meetings with your team.</p>
+        </div>
+        <BookingDialog />
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
+        {/* Calendar Widget */}
+        <Card className="lg:col-span-1">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <CalendarIcon className="size-5" />
+              Calendar
+            </CardTitle>
+            <CardDescription>Select a date to view scheduled events</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Calendar
+              mode="single"
+              selected={selectedDate}
+              onSelect={setSelectedDate}
+              className="rounded-md border-0 w-full"
+            />
+          </CardContent>
+        </Card>
+
+        {/* Events for Selected Date */}
+        <Card className="lg:col-span-2">
+          <CardHeader>
+            <CardTitle>
+              Events for{" "}
+              {selectedDate?.toLocaleDateString("en-US", {
+                weekday: "long",
+                year: "numeric",
+                month: "long",
+                day: "numeric",
+              })}
+            </CardTitle>
+            <CardDescription>{mockEvents.length} events scheduled for this day</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-4">
+              {mockEvents.length > 0 ? (
+                mockEvents.map((event) => <EventCard key={event.id} event={event} />)
+              ) : (
+                <div className="text-center py-12">
+                  <CalendarIcon className="mx-auto size-12 text-muted-foreground mb-4" />
+                  <h3 className="text-lg font-medium text-muted-foreground mb-2">No events scheduled</h3>
+                  <p className="text-sm text-muted-foreground mb-4">
+                    You don&apos;t have any events scheduled for this day.
+                  </p>
+                  <BookingDialog />
+                </div>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Quick Stats */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <Card>
+          <CardContent className="p-6">
+            <div className="flex items-center gap-4">
+              <div className="p-2 bg-blue-100 dark:bg-blue-900 rounded-lg">
+                <CalendarIcon className="size-6 text-blue-600 dark:text-blue-400" />
+              </div>
+              <div>
+                <p className="text-sm font-medium text-muted-foreground">Today</p>
+                <p className="text-2xl font-bold">{mockEvents.length}</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="p-6">
+            <div className="flex items-center gap-4">
+              <div className="p-2 bg-green-100 dark:bg-green-900 rounded-lg">
+                <Clock className="size-6 text-green-600 dark:text-green-400" />
+              </div>
+              <div>
+                <p className="text-sm font-medium text-muted-foreground">This Week</p>
+                <p className="text-2xl font-bold">12</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="p-6">
+            <div className="flex items-center gap-4">
+              <div className="p-2 bg-purple-100 dark:bg-purple-900 rounded-lg">
+                <Users className="size-6 text-purple-600 dark:text-purple-400" />
+              </div>
+              <div>
+                <p className="text-sm font-medium text-muted-foreground">Total Attendees</p>
+                <p className="text-2xl font-bold">{mockEvents.reduce((sum, event) => sum + event.attendees, 0)}</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent className="p-6">
+            <div className="flex items-center gap-4">
+              <div className="p-2 bg-orange-100 dark:bg-orange-900 rounded-lg">
+                <MapPin className="size-6 text-orange-600 dark:text-orange-400" />
+              </div>
+              <div>
+                <p className="text-sm font-medium text-muted-foreground">Locations</p>
+                <p className="text-2xl font-bold">{new Set(mockEvents.map((event) => event.location)).size}</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/dashboard/design/page.tsx
+++ b/src/app/(main)/dashboard/design/page.tsx
@@ -12,15 +12,7 @@ const CodeBlock = ({ children, title }: { children: string; title: string }) => 
   </div>
 );
 
-const BannerExample = ({
-  title,
-  code,
-  children,
-}: {
-  title: string;
-  code: string;
-  children: React.ReactNode;
-}) => (
+const BannerExample = ({ title, code, children }: { title: string; code: string; children: React.ReactNode }) => (
   <div className="space-y-4">
     <h3 className="text-lg font-semibold">{title}</h3>
     <div className="space-y-4">
@@ -56,10 +48,7 @@ export default function Page() {
               Banner components for displaying important information with optional actions.
             </p>
           </div>
-          <button
-            onClick={resetDismissed}
-            className="text-xs text-muted-foreground hover:text-foreground underline"
-          >
+          <button onClick={resetDismissed} className="text-xs text-muted-foreground hover:text-foreground underline">
             Reset dismissed banners
           </button>
         </div>
@@ -259,12 +248,13 @@ export default function Page() {
                   <div>
                     <span className="font-mono bg-muted px-1.5 py-0.5 rounded">variant</span>
                     <span className="text-muted-foreground ml-2">
-                      "info" | "info-neutral" | "error" | "warning" | "success"
+                      &quot;info&quot; | &quot;info-neutral&quot; | &quot;error&quot; | &quot;warning&quot; |
+                      &quot;success&quot;
                     </span>
                   </div>
                   <div>
                     <span className="font-mono bg-muted px-1.5 py-0.5 rounded">layout</span>
-                    <span className="text-muted-foreground ml-2">"inline" | "block"</span>
+                    <span className="text-muted-foreground ml-2">&quot;inline&quot; | &quot;block&quot;</span>
                   </div>
                   <div>
                     <span className="font-mono bg-muted px-1.5 py-0.5 rounded">heading</span>
@@ -276,7 +266,7 @@ export default function Page() {
                   </div>
                   <div>
                     <span className="font-mono bg-muted px-1.5 py-0.5 rounded">onDismiss</span>
-                    <span className="text-muted-foreground ml-2">() => void (optional)</span>
+                    <span className="text-muted-foreground ml-2">() =&gt; void (optional)</span>
                   </div>
                   <div>
                     <span className="font-mono bg-muted px-1.5 py-0.5 rounded">primaryAction</span>

--- a/src/app/(main)/dashboard/design/page.tsx
+++ b/src/app/(main)/dashboard/design/page.tsx
@@ -54,9 +54,17 @@ export default function Page() {
         </div>
 
         {/* Inline Variants */}
-        <BannerExample
-          title="Inline Banners"
-          code={`<Banner
+        <div className="space-y-6">
+          <div>
+            <h3 className="text-lg font-semibold mb-4">Inline Banners</h3>
+            <p className="text-sm text-muted-foreground mb-6">Single line banners with actions and dismiss options.</p>
+          </div>
+
+          {/* Inline Info */}
+          <div className="space-y-4">
+            <CodeBlock
+              title="Inline Info Banner"
+              children={`<Banner
   layout="inline"
   variant="info"
   primaryAction={{ label: "Primary Action", onClick: () => {} }}
@@ -64,62 +72,119 @@ export default function Page() {
 >
   Single line information with an action and dismiss option
 </Banner>`}
-        >
-          {!dismissedBanners.has("inline-info") && (
-            <Banner
-              layout="inline"
-              variant="info"
-              primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
-              onDismiss={() => handleDismiss("inline-info")}
-            >
-              Single line information with an action and dismiss option
-            </Banner>
-          )}
+            />
+            {!dismissedBanners.has("inline-info") && (
+              <Banner
+                layout="inline"
+                variant="info"
+                primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
+                onDismiss={() => handleDismiss("inline-info")}
+              >
+                Single line information with an action and dismiss option
+              </Banner>
+            )}
+          </div>
 
-          {!dismissedBanners.has("inline-neutral") && (
-            <Banner
-              layout="inline"
-              variant="info-neutral"
-              primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
-              onDismiss={() => handleDismiss("inline-neutral")}
-            >
-              Single line information with an action and dismiss option
-            </Banner>
-          )}
+          {/* Inline Neutral */}
+          <div className="space-y-4">
+            <CodeBlock
+              title="Inline Neutral Banner"
+              children={`<Banner
+  layout="inline"
+  variant="info-neutral"
+  primaryAction={{ label: "Primary Action", onClick: () => {} }}
+  onDismiss={() => {}}
+>
+  Single line information with an action and dismiss option
+</Banner>`}
+            />
+            {!dismissedBanners.has("inline-neutral") && (
+              <Banner
+                layout="inline"
+                variant="info-neutral"
+                primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
+                onDismiss={() => handleDismiss("inline-neutral")}
+              >
+                Single line information with an action and dismiss option
+              </Banner>
+            )}
+          </div>
 
-          {!dismissedBanners.has("inline-error") && (
-            <Banner
-              layout="inline"
-              variant="error"
-              primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
-              onDismiss={() => handleDismiss("inline-error")}
-            >
-              Single line information with an action and dismiss option
-            </Banner>
-          )}
+          {/* Inline Error */}
+          <div className="space-y-4">
+            <CodeBlock
+              title="Inline Error Banner"
+              children={`<Banner
+  layout="inline"
+  variant="error"
+  primaryAction={{ label: "Primary Action", onClick: () => {} }}
+  onDismiss={() => {}}
+>
+  Single line information with an action and dismiss option
+</Banner>`}
+            />
+            {!dismissedBanners.has("inline-error") && (
+              <Banner
+                layout="inline"
+                variant="error"
+                primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
+                onDismiss={() => handleDismiss("inline-error")}
+              >
+                Single line information with an action and dismiss option
+              </Banner>
+            )}
+          </div>
 
-          {!dismissedBanners.has("inline-warning") && (
-            <Banner
-              layout="inline"
-              variant="warning"
-              primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
-              onDismiss={() => handleDismiss("inline-warning")}
-            >
-              Single line information with an action and dismiss option
-            </Banner>
-          )}
+          {/* Inline Warning */}
+          <div className="space-y-4">
+            <CodeBlock
+              title="Inline Warning Banner"
+              children={`<Banner
+  layout="inline"
+  variant="warning"
+  primaryAction={{ label: "Primary Action", onClick: () => {} }}
+  onDismiss={() => {}}
+>
+  Single line information with an action and dismiss option
+</Banner>`}
+            />
+            {!dismissedBanners.has("inline-warning") && (
+              <Banner
+                layout="inline"
+                variant="warning"
+                primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
+                onDismiss={() => handleDismiss("inline-warning")}
+              >
+                Single line information with an action and dismiss option
+              </Banner>
+            )}
+          </div>
 
-          {!dismissedBanners.has("inline-success") && (
-            <Banner
-              layout="inline"
-              variant="success"
-              primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
-              onDismiss={() => handleDismiss("inline-success")}
-            >
-              Single line information with an action and dismiss option
-            </Banner>
-          )}
-        </BannerExample>
+          {/* Inline Success */}
+          <div className="space-y-4">
+            <CodeBlock
+              title="Inline Success Banner"
+              children={`<Banner
+  layout="inline"
+  variant="success"
+  primaryAction={{ label: "Primary Action", onClick: () => {} }}
+  onDismiss={() => {}}
+>
+  Single line information with an action and dismiss option
+</Banner>`}
+            />
+            {!dismissedBanners.has("inline-success") && (
+              <Banner
+                layout="inline"
+                variant="success"
+                primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
+                onDismiss={() => handleDismiss("inline-success")}
+              >
+                Single line information with an action and dismiss option
+              </Banner>
+            )}
+          </div>
+        </div>
 
         {/* Block Variants */}
         <BannerExample

--- a/src/app/(main)/dashboard/design/page.tsx
+++ b/src/app/(main)/dashboard/design/page.tsx
@@ -1,0 +1,22 @@
+export default function Page() {
+  return (
+    <div className="@container/main flex flex-col gap-4 md:gap-6">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-bold tracking-tight">Design System</h1>
+        <p className="text-muted-foreground">A comprehensive collection of reusable components and design patterns.</p>
+      </div>
+
+      <div className="space-y-4">
+        <div>
+          <h2 className="text-xl font-semibold">Banners</h2>
+          <p className="text-muted-foreground text-sm">Banner components and variations will be displayed here.</p>
+        </div>
+
+        {/* Content will be added later */}
+        <div className="rounded-lg border border-dashed border-muted-foreground/25 p-8 text-center">
+          <p className="text-muted-foreground">Content coming soon...</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(main)/dashboard/design/page.tsx
+++ b/src/app/(main)/dashboard/design/page.tsx
@@ -187,9 +187,19 @@ export default function Page() {
         </div>
 
         {/* Block Variants */}
-        <BannerExample
-          title="Block Banners with Heading and Actions"
-          code={`<Banner
+        <div className="space-y-6">
+          <div>
+            <h3 className="text-lg font-semibold mb-4">Block Banners with Heading and Actions</h3>
+            <p className="text-sm text-muted-foreground mb-6">
+              Multi-line banners with heading, description, and action buttons.
+            </p>
+          </div>
+
+          {/* Block Info */}
+          <div className="space-y-4">
+            <CodeBlock
+              title="Block Info Banner"
+              children={`<Banner
   variant="info"
   heading="At the moment, we are unable to identify the cause of the connection problem."
   primaryAction={{ label: "Primary Action", onClick: () => {} }}
@@ -198,67 +208,128 @@ export default function Page() {
 >
   Get help from the Builder community. This is the best place to get technical assistance from the team
 </Banner>`}
-        >
-          {!dismissedBanners.has("block-info") && (
-            <Banner
-              variant="info"
-              heading="At the moment, we are unable to identify the cause of the connection problem."
-              primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
-              secondaryAction={{ label: "Secondary Action", onClick: () => console.log("Secondary clicked") }}
-              onDismiss={() => handleDismiss("block-info")}
-            >
-              Get help from the Builder community. This is the best place to get technical assistance from the team
-            </Banner>
-          )}
+            />
+            {!dismissedBanners.has("block-info") && (
+              <Banner
+                variant="info"
+                heading="At the moment, we are unable to identify the cause of the connection problem."
+                primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
+                secondaryAction={{ label: "Secondary Action", onClick: () => console.log("Secondary clicked") }}
+                onDismiss={() => handleDismiss("block-info")}
+              >
+                Get help from the Builder community. This is the best place to get technical assistance from the team
+              </Banner>
+            )}
+          </div>
 
-          {!dismissedBanners.has("block-neutral") && (
-            <Banner
-              variant="info-neutral"
-              heading="At the moment, we are unable to identify the cause of the connection problem."
-              primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
-              secondaryAction={{ label: "Secondary Action", onClick: () => console.log("Secondary clicked") }}
-              onDismiss={() => handleDismiss("block-neutral")}
-            >
-              Get help from the Builder community. This is the best place to get technical assistance from the team
-            </Banner>
-          )}
+          {/* Block Neutral */}
+          <div className="space-y-4">
+            <CodeBlock
+              title="Block Neutral Banner"
+              children={`<Banner
+  variant="info-neutral"
+  heading="At the moment, we are unable to identify the cause of the connection problem."
+  primaryAction={{ label: "Primary Action", onClick: () => {} }}
+  secondaryAction={{ label: "Secondary Action", onClick: () => {} }}
+  onDismiss={() => {}}
+>
+  Get help from the Builder community. This is the best place to get technical assistance from the team
+</Banner>`}
+            />
+            {!dismissedBanners.has("block-neutral") && (
+              <Banner
+                variant="info-neutral"
+                heading="At the moment, we are unable to identify the cause of the connection problem."
+                primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
+                secondaryAction={{ label: "Secondary Action", onClick: () => console.log("Secondary clicked") }}
+                onDismiss={() => handleDismiss("block-neutral")}
+              >
+                Get help from the Builder community. This is the best place to get technical assistance from the team
+              </Banner>
+            )}
+          </div>
 
-          {!dismissedBanners.has("block-error") && (
-            <Banner
-              variant="error"
-              heading="At the moment, we are unable to identify the cause of the connection problem."
-              primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
-              secondaryAction={{ label: "Secondary Action", onClick: () => console.log("Secondary clicked") }}
-              onDismiss={() => handleDismiss("block-error")}
-            >
-              Get help from the Builder community. This is the best place to get technical assistance from the team
-            </Banner>
-          )}
+          {/* Block Error */}
+          <div className="space-y-4">
+            <CodeBlock
+              title="Block Error Banner"
+              children={`<Banner
+  variant="error"
+  heading="At the moment, we are unable to identify the cause of the connection problem."
+  primaryAction={{ label: "Primary Action", onClick: () => {} }}
+  secondaryAction={{ label: "Secondary Action", onClick: () => {} }}
+  onDismiss={() => {}}
+>
+  Get help from the Builder community. This is the best place to get technical assistance from the team
+</Banner>`}
+            />
+            {!dismissedBanners.has("block-error") && (
+              <Banner
+                variant="error"
+                heading="At the moment, we are unable to identify the cause of the connection problem."
+                primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
+                secondaryAction={{ label: "Secondary Action", onClick: () => console.log("Secondary clicked") }}
+                onDismiss={() => handleDismiss("block-error")}
+              >
+                Get help from the Builder community. This is the best place to get technical assistance from the team
+              </Banner>
+            )}
+          </div>
 
-          {!dismissedBanners.has("block-warning") && (
-            <Banner
-              variant="warning"
-              heading="At the moment, we are unable to identify the cause of the connection problem."
-              primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
-              secondaryAction={{ label: "Secondary Action", onClick: () => console.log("Secondary clicked") }}
-              onDismiss={() => handleDismiss("block-warning")}
-            >
-              Get help from the Builder community. This is the best place to get technical assistance from the team
-            </Banner>
-          )}
+          {/* Block Warning */}
+          <div className="space-y-4">
+            <CodeBlock
+              title="Block Warning Banner"
+              children={`<Banner
+  variant="warning"
+  heading="At the moment, we are unable to identify the cause of the connection problem."
+  primaryAction={{ label: "Primary Action", onClick: () => {} }}
+  secondaryAction={{ label: "Secondary Action", onClick: () => {} }}
+  onDismiss={() => {}}
+>
+  Get help from the Builder community. This is the best place to get technical assistance from the team
+</Banner>`}
+            />
+            {!dismissedBanners.has("block-warning") && (
+              <Banner
+                variant="warning"
+                heading="At the moment, we are unable to identify the cause of the connection problem."
+                primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
+                secondaryAction={{ label: "Secondary Action", onClick: () => console.log("Secondary clicked") }}
+                onDismiss={() => handleDismiss("block-warning")}
+              >
+                Get help from the Builder community. This is the best place to get technical assistance from the team
+              </Banner>
+            )}
+          </div>
 
-          {!dismissedBanners.has("block-success") && (
-            <Banner
-              variant="success"
-              heading="At the moment, we are unable to identify the cause of the connection problem."
-              primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
-              secondaryAction={{ label: "Secondary Action", onClick: () => console.log("Secondary clicked") }}
-              onDismiss={() => handleDismiss("block-success")}
-            >
-              Get help from the Builder community. This is the best place to get technical assistance from the team
-            </Banner>
-          )}
-        </BannerExample>
+          {/* Block Success */}
+          <div className="space-y-4">
+            <CodeBlock
+              title="Block Success Banner"
+              children={`<Banner
+  variant="success"
+  heading="At the moment, we are unable to identify the cause of the connection problem."
+  primaryAction={{ label: "Primary Action", onClick: () => {} }}
+  secondaryAction={{ label: "Secondary Action", onClick: () => {} }}
+  onDismiss={() => {}}
+>
+  Get help from the Builder community. This is the best place to get technical assistance from the team
+</Banner>`}
+            />
+            {!dismissedBanners.has("block-success") && (
+              <Banner
+                variant="success"
+                heading="At the moment, we are unable to identify the cause of the connection problem."
+                primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
+                secondaryAction={{ label: "Secondary Action", onClick: () => console.log("Secondary clicked") }}
+                onDismiss={() => handleDismiss("block-success")}
+              >
+                Get help from the Builder community. This is the best place to get technical assistance from the team
+              </Banner>
+            )}
+          </div>
+        </div>
 
         {/* Configuration Examples */}
         <BannerExample

--- a/src/app/(main)/dashboard/design/page.tsx
+++ b/src/app/(main)/dashboard/design/page.tsx
@@ -359,55 +359,63 @@ export default function Page() {
           </div>
 
           {/* Without dismiss button */}
-          <div className="space-y-4">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
             <CodeBlock
               title="Banner without dismiss button"
               children={`<Banner variant="info" showDismiss={false}>
   This banner cannot be dismissed
 </Banner>`}
             />
-            <Banner variant="info" showDismiss={false}>
-              This banner cannot be dismissed
-            </Banner>
+            <div className="flex items-center">
+              <Banner variant="info" showDismiss={false}>
+                This banner cannot be dismissed
+              </Banner>
+            </div>
           </div>
 
           {/* Without icon */}
-          <div className="space-y-4">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
             <CodeBlock
               title="Banner without icon"
               children={`<Banner variant="warning" showIcon={false} onDismiss={() => {}}>
   This banner has no icon
 </Banner>`}
             />
-            <Banner variant="warning" showIcon={false} onDismiss={() => console.log("Dismissed")}>
-              This banner has no icon
-            </Banner>
+            <div className="flex items-center">
+              <Banner variant="warning" showIcon={false} onDismiss={() => console.log("Dismissed")}>
+                This banner has no icon
+              </Banner>
+            </div>
           </div>
 
           {/* Without actions */}
-          <div className="space-y-4">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
             <CodeBlock
               title="Banner without actions"
               children={`<Banner variant="success" heading="Success!" onDismiss={() => {}}>
   Operation completed successfully
 </Banner>`}
             />
-            <Banner variant="success" heading="Success!" onDismiss={() => console.log("Dismissed")}>
-              Operation completed successfully
-            </Banner>
+            <div className="flex items-start">
+              <Banner variant="success" heading="Success!" onDismiss={() => console.log("Dismissed")}>
+                Operation completed successfully
+              </Banner>
+            </div>
           </div>
 
           {/* Custom className */}
-          <div className="space-y-4">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
             <CodeBlock
               title="Banner with custom styling"
               children={`<Banner variant="error" className="border-2 border-dashed" onDismiss={() => {}}>
   Custom styled banner with dashed border
 </Banner>`}
             />
-            <Banner variant="error" className="border-2 border-dashed" onDismiss={() => console.log("Dismissed")}>
-              Custom styled banner with dashed border
-            </Banner>
+            <div className="flex items-center">
+              <Banner variant="error" className="border-2 border-dashed" onDismiss={() => console.log("Dismissed")}>
+                Custom styled banner with dashed border
+              </Banner>
+            </div>
           </div>
         </div>
 

--- a/src/app/(main)/dashboard/design/page.tsx
+++ b/src/app/(main)/dashboard/design/page.tsx
@@ -366,7 +366,7 @@ export default function Page() {
   This banner cannot be dismissed
 </Banner>`}
             />
-            <div className="flex items-center">
+            <div className="flex items-start pt-6">
               <Banner variant="info" showDismiss={false}>
                 This banner cannot be dismissed
               </Banner>
@@ -381,7 +381,7 @@ export default function Page() {
   This banner has no icon
 </Banner>`}
             />
-            <div className="flex items-center">
+            <div className="flex items-start pt-6">
               <Banner variant="warning" showIcon={false} onDismiss={() => console.log("Dismissed")}>
                 This banner has no icon
               </Banner>
@@ -396,7 +396,7 @@ export default function Page() {
   Operation completed successfully
 </Banner>`}
             />
-            <div className="flex items-start">
+            <div className="flex items-start pt-6">
               <Banner variant="success" heading="Success!" onDismiss={() => console.log("Dismissed")}>
                 Operation completed successfully
               </Banner>
@@ -411,7 +411,7 @@ export default function Page() {
   Custom styled banner with dashed border
 </Banner>`}
             />
-            <div className="flex items-center">
+            <div className="flex items-start pt-6">
               <Banner variant="error" className="border-2 border-dashed" onDismiss={() => console.log("Dismissed")}>
                 Custom styled banner with dashed border
               </Banner>

--- a/src/app/(main)/dashboard/design/page.tsx
+++ b/src/app/(main)/dashboard/design/page.tsx
@@ -206,7 +206,7 @@ export default function Page() {
           </div>
 
           {/* Block Info */}
-          <div className="space-y-4">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
             <CodeBlock
               title="Block Info Banner"
               children={`<Banner
@@ -219,21 +219,23 @@ export default function Page() {
   Get help from the Builder community. This is the best place to get technical assistance from the team
 </Banner>`}
             />
-            {!dismissedBanners.has("block-info") && (
-              <Banner
-                variant="info"
-                heading="At the moment, we are unable to identify the cause of the connection problem."
-                primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
-                secondaryAction={{ label: "Secondary Action", onClick: () => console.log("Secondary clicked") }}
-                onDismiss={() => handleDismiss("block-info")}
-              >
-                Get help from the Builder community. This is the best place to get technical assistance from the team
-              </Banner>
-            )}
+            <div className="flex items-start">
+              {!dismissedBanners.has("block-info") && (
+                <Banner
+                  variant="info"
+                  heading="At the moment, we are unable to identify the cause of the connection problem."
+                  primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
+                  secondaryAction={{ label: "Secondary Action", onClick: () => console.log("Secondary clicked") }}
+                  onDismiss={() => handleDismiss("block-info")}
+                >
+                  Get help from the Builder community. This is the best place to get technical assistance from the team
+                </Banner>
+              )}
+            </div>
           </div>
 
           {/* Block Neutral */}
-          <div className="space-y-4">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
             <CodeBlock
               title="Block Neutral Banner"
               children={`<Banner
@@ -246,21 +248,23 @@ export default function Page() {
   Get help from the Builder community. This is the best place to get technical assistance from the team
 </Banner>`}
             />
-            {!dismissedBanners.has("block-neutral") && (
-              <Banner
-                variant="info-neutral"
-                heading="At the moment, we are unable to identify the cause of the connection problem."
-                primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
-                secondaryAction={{ label: "Secondary Action", onClick: () => console.log("Secondary clicked") }}
-                onDismiss={() => handleDismiss("block-neutral")}
-              >
-                Get help from the Builder community. This is the best place to get technical assistance from the team
-              </Banner>
-            )}
+            <div className="flex items-start">
+              {!dismissedBanners.has("block-neutral") && (
+                <Banner
+                  variant="info-neutral"
+                  heading="At the moment, we are unable to identify the cause of the connection problem."
+                  primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
+                  secondaryAction={{ label: "Secondary Action", onClick: () => console.log("Secondary clicked") }}
+                  onDismiss={() => handleDismiss("block-neutral")}
+                >
+                  Get help from the Builder community. This is the best place to get technical assistance from the team
+                </Banner>
+              )}
+            </div>
           </div>
 
           {/* Block Error */}
-          <div className="space-y-4">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
             <CodeBlock
               title="Block Error Banner"
               children={`<Banner
@@ -273,21 +277,23 @@ export default function Page() {
   Get help from the Builder community. This is the best place to get technical assistance from the team
 </Banner>`}
             />
-            {!dismissedBanners.has("block-error") && (
-              <Banner
-                variant="error"
-                heading="At the moment, we are unable to identify the cause of the connection problem."
-                primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
-                secondaryAction={{ label: "Secondary Action", onClick: () => console.log("Secondary clicked") }}
-                onDismiss={() => handleDismiss("block-error")}
-              >
-                Get help from the Builder community. This is the best place to get technical assistance from the team
-              </Banner>
-            )}
+            <div className="flex items-start">
+              {!dismissedBanners.has("block-error") && (
+                <Banner
+                  variant="error"
+                  heading="At the moment, we are unable to identify the cause of the connection problem."
+                  primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
+                  secondaryAction={{ label: "Secondary Action", onClick: () => console.log("Secondary clicked") }}
+                  onDismiss={() => handleDismiss("block-error")}
+                >
+                  Get help from the Builder community. This is the best place to get technical assistance from the team
+                </Banner>
+              )}
+            </div>
           </div>
 
           {/* Block Warning */}
-          <div className="space-y-4">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
             <CodeBlock
               title="Block Warning Banner"
               children={`<Banner
@@ -300,21 +306,23 @@ export default function Page() {
   Get help from the Builder community. This is the best place to get technical assistance from the team
 </Banner>`}
             />
-            {!dismissedBanners.has("block-warning") && (
-              <Banner
-                variant="warning"
-                heading="At the moment, we are unable to identify the cause of the connection problem."
-                primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
-                secondaryAction={{ label: "Secondary Action", onClick: () => console.log("Secondary clicked") }}
-                onDismiss={() => handleDismiss("block-warning")}
-              >
-                Get help from the Builder community. This is the best place to get technical assistance from the team
-              </Banner>
-            )}
+            <div className="flex items-start">
+              {!dismissedBanners.has("block-warning") && (
+                <Banner
+                  variant="warning"
+                  heading="At the moment, we are unable to identify the cause of the connection problem."
+                  primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
+                  secondaryAction={{ label: "Secondary Action", onClick: () => console.log("Secondary clicked") }}
+                  onDismiss={() => handleDismiss("block-warning")}
+                >
+                  Get help from the Builder community. This is the best place to get technical assistance from the team
+                </Banner>
+              )}
+            </div>
           </div>
 
           {/* Block Success */}
-          <div className="space-y-4">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
             <CodeBlock
               title="Block Success Banner"
               children={`<Banner
@@ -327,17 +335,19 @@ export default function Page() {
   Get help from the Builder community. This is the best place to get technical assistance from the team
 </Banner>`}
             />
-            {!dismissedBanners.has("block-success") && (
-              <Banner
-                variant="success"
-                heading="At the moment, we are unable to identify the cause of the connection problem."
-                primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
-                secondaryAction={{ label: "Secondary Action", onClick: () => console.log("Secondary clicked") }}
-                onDismiss={() => handleDismiss("block-success")}
-              >
-                Get help from the Builder community. This is the best place to get technical assistance from the team
-              </Banner>
-            )}
+            <div className="flex items-start">
+              {!dismissedBanners.has("block-success") && (
+                <Banner
+                  variant="success"
+                  heading="At the moment, we are unable to identify the cause of the connection problem."
+                  primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
+                  secondaryAction={{ label: "Secondary Action", onClick: () => console.log("Secondary clicked") }}
+                  onDismiss={() => handleDismiss("block-success")}
+                >
+                  Get help from the Builder community. This is the best place to get technical assistance from the team
+                </Banner>
+              )}
+            </div>
           </div>
         </div>
 

--- a/src/app/(main)/dashboard/design/page.tsx
+++ b/src/app/(main)/dashboard/design/page.tsx
@@ -100,7 +100,7 @@ export default function Page() {
   Single line information with an action and dismiss option
 </Banner>`}
             />
-            <div className="flex items-center">
+            <div className="flex items-start pt-6">
               {!dismissedBanners.has("inline-neutral") && (
                 <Banner
                   layout="inline"
@@ -127,7 +127,7 @@ export default function Page() {
   Single line information with an action and dismiss option
 </Banner>`}
             />
-            <div className="flex items-center">
+            <div className="flex items-start pt-6">
               {!dismissedBanners.has("inline-error") && (
                 <Banner
                   layout="inline"
@@ -154,7 +154,7 @@ export default function Page() {
   Single line information with an action and dismiss option
 </Banner>`}
             />
-            <div className="flex items-center">
+            <div className="flex items-start pt-6">
               {!dismissedBanners.has("inline-warning") && (
                 <Banner
                   layout="inline"
@@ -181,7 +181,7 @@ export default function Page() {
   Single line information with an action and dismiss option
 </Banner>`}
             />
-            <div className="flex items-center">
+            <div className="flex items-start pt-6">
               {!dismissedBanners.has("inline-success") && (
                 <Banner
                   layout="inline"

--- a/src/app/(main)/dashboard/design/page.tsx
+++ b/src/app/(main)/dashboard/design/page.tsx
@@ -332,46 +332,64 @@ export default function Page() {
         </div>
 
         {/* Configuration Examples */}
-        <BannerExample
-          title="Configuration Options"
-          code={`// Without dismiss button
-<Banner variant="info" showDismiss={false}>
-  This banner cannot be dismissed
-</Banner>
+        <div className="space-y-6">
+          <div>
+            <h3 className="text-lg font-semibold mb-4">Configuration Options</h3>
+            <p className="text-sm text-muted-foreground mb-6">Examples of different banner configurations and customizations.</p>
+          </div>
 
-// Without icon
-<Banner variant="warning" showIcon={false}>
-  This banner has no icon
-</Banner>
-
-// Without actions
-<Banner variant="success" heading="Success!" onDismiss={() => {}}>
-  Operation completed successfully
-</Banner>
-
-// Custom className
-<Banner variant="error" className="border-2 border-dashed">
-  Custom styled banner
-</Banner>`}
-        >
+          {/* Without dismiss button */}
           <div className="space-y-4">
+            <CodeBlock
+              title="Banner without dismiss button"
+              children={`<Banner variant="info" showDismiss={false}>
+  This banner cannot be dismissed
+</Banner>`}
+            />
             <Banner variant="info" showDismiss={false}>
               This banner cannot be dismissed
             </Banner>
+          </div>
 
+          {/* Without icon */}
+          <div className="space-y-4">
+            <CodeBlock
+              title="Banner without icon"
+              children={`<Banner variant="warning" showIcon={false} onDismiss={() => {}}>
+  This banner has no icon
+</Banner>`}
+            />
             <Banner variant="warning" showIcon={false} onDismiss={() => console.log("Dismissed")}>
               This banner has no icon
             </Banner>
+          </div>
 
+          {/* Without actions */}
+          <div className="space-y-4">
+            <CodeBlock
+              title="Banner without actions"
+              children={`<Banner variant="success" heading="Success!" onDismiss={() => {}}>
+  Operation completed successfully
+</Banner>`}
+            />
             <Banner variant="success" heading="Success!" onDismiss={() => console.log("Dismissed")}>
               Operation completed successfully
             </Banner>
+          </div>
 
+          {/* Custom className */}
+          <div className="space-y-4">
+            <CodeBlock
+              title="Banner with custom styling"
+              children={`<Banner variant="error" className="border-2 border-dashed" onDismiss={() => {}}>
+  Custom styled banner with dashed border
+</Banner>`}
+            />
             <Banner variant="error" className="border-2 border-dashed" onDismiss={() => console.log("Dismissed")}>
               Custom styled banner with dashed border
             </Banner>
           </div>
-        </BannerExample>
+        </div>
 
         {/* Props Documentation */}
         <div className="space-y-4">

--- a/src/app/(main)/dashboard/design/page.tsx
+++ b/src/app/(main)/dashboard/design/page.tsx
@@ -1,16 +1,41 @@
 "use client";
 
 import { useState } from "react";
+import { Copy, Check } from "lucide-react";
 import { Banner } from "@/components/ui/banner";
 
-const CodeBlock = ({ children, title }: { children: string; title: string }) => (
-  <div className="space-y-2">
-    <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">{title}</h4>
-    <pre className="bg-muted/50 rounded-lg p-3 text-xs overflow-x-auto">
-      <code>{children}</code>
-    </pre>
-  </div>
-);
+const CodeBlock = ({ children, title }: { children: string; title: string }) => {
+  const [copied, setCopied] = useState(false);
+
+  const copyToClipboard = async () => {
+    try {
+      await navigator.clipboard.writeText(children);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error("Failed to copy text: ", err);
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">{title}</h4>
+        <button
+          onClick={copyToClipboard}
+          className="flex items-center gap-1 rounded-md px-2 py-1 text-xs text-muted-foreground hover:bg-muted/50 hover:text-foreground transition-colors"
+          title={copied ? "Copied!" : "Copy to clipboard"}
+        >
+          {copied ? <Check className="size-3" /> : <Copy className="size-3" />}
+          {copied ? "Copied!" : "Copy"}
+        </button>
+      </div>
+      <pre className="bg-muted/50 rounded-lg p-3 text-xs overflow-x-auto">
+        <code>{children}</code>
+      </pre>
+    </div>
+  );
+};
 
 const BannerExample = ({ title, code, children }: { title: string; code: string; children: React.ReactNode }) => (
   <div className="space-y-4">

--- a/src/app/(main)/dashboard/design/page.tsx
+++ b/src/app/(main)/dashboard/design/page.tsx
@@ -61,7 +61,7 @@ export default function Page() {
           </div>
 
           {/* Inline Info */}
-          <div className="space-y-4">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
             <CodeBlock
               title="Inline Info Banner"
               children={`<Banner
@@ -73,20 +73,22 @@ export default function Page() {
   Single line information with an action and dismiss option
 </Banner>`}
             />
-            {!dismissedBanners.has("inline-info") && (
-              <Banner
-                layout="inline"
-                variant="info"
-                primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
-                onDismiss={() => handleDismiss("inline-info")}
-              >
-                Single line information with an action and dismiss option
-              </Banner>
-            )}
+            <div className="flex items-center">
+              {!dismissedBanners.has("inline-info") && (
+                <Banner
+                  layout="inline"
+                  variant="info"
+                  primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
+                  onDismiss={() => handleDismiss("inline-info")}
+                >
+                  Single line information with an action and dismiss option
+                </Banner>
+              )}
+            </div>
           </div>
 
           {/* Inline Neutral */}
-          <div className="space-y-4">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
             <CodeBlock
               title="Inline Neutral Banner"
               children={`<Banner
@@ -98,20 +100,22 @@ export default function Page() {
   Single line information with an action and dismiss option
 </Banner>`}
             />
-            {!dismissedBanners.has("inline-neutral") && (
-              <Banner
-                layout="inline"
-                variant="info-neutral"
-                primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
-                onDismiss={() => handleDismiss("inline-neutral")}
-              >
-                Single line information with an action and dismiss option
-              </Banner>
-            )}
+            <div className="flex items-center">
+              {!dismissedBanners.has("inline-neutral") && (
+                <Banner
+                  layout="inline"
+                  variant="info-neutral"
+                  primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
+                  onDismiss={() => handleDismiss("inline-neutral")}
+                >
+                  Single line information with an action and dismiss option
+                </Banner>
+              )}
+            </div>
           </div>
 
           {/* Inline Error */}
-          <div className="space-y-4">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
             <CodeBlock
               title="Inline Error Banner"
               children={`<Banner
@@ -123,20 +127,22 @@ export default function Page() {
   Single line information with an action and dismiss option
 </Banner>`}
             />
-            {!dismissedBanners.has("inline-error") && (
-              <Banner
-                layout="inline"
-                variant="error"
-                primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
-                onDismiss={() => handleDismiss("inline-error")}
-              >
-                Single line information with an action and dismiss option
-              </Banner>
-            )}
+            <div className="flex items-center">
+              {!dismissedBanners.has("inline-error") && (
+                <Banner
+                  layout="inline"
+                  variant="error"
+                  primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
+                  onDismiss={() => handleDismiss("inline-error")}
+                >
+                  Single line information with an action and dismiss option
+                </Banner>
+              )}
+            </div>
           </div>
 
           {/* Inline Warning */}
-          <div className="space-y-4">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
             <CodeBlock
               title="Inline Warning Banner"
               children={`<Banner
@@ -148,20 +154,22 @@ export default function Page() {
   Single line information with an action and dismiss option
 </Banner>`}
             />
-            {!dismissedBanners.has("inline-warning") && (
-              <Banner
-                layout="inline"
-                variant="warning"
-                primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
-                onDismiss={() => handleDismiss("inline-warning")}
-              >
-                Single line information with an action and dismiss option
-              </Banner>
-            )}
+            <div className="flex items-center">
+              {!dismissedBanners.has("inline-warning") && (
+                <Banner
+                  layout="inline"
+                  variant="warning"
+                  primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
+                  onDismiss={() => handleDismiss("inline-warning")}
+                >
+                  Single line information with an action and dismiss option
+                </Banner>
+              )}
+            </div>
           </div>
 
           {/* Inline Success */}
-          <div className="space-y-4">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
             <CodeBlock
               title="Inline Success Banner"
               children={`<Banner
@@ -173,16 +181,18 @@ export default function Page() {
   Single line information with an action and dismiss option
 </Banner>`}
             />
-            {!dismissedBanners.has("inline-success") && (
-              <Banner
-                layout="inline"
-                variant="success"
-                primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
-                onDismiss={() => handleDismiss("inline-success")}
-              >
-                Single line information with an action and dismiss option
-              </Banner>
-            )}
+            <div className="flex items-center">
+              {!dismissedBanners.has("inline-success") && (
+                <Banner
+                  layout="inline"
+                  variant="success"
+                  primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
+                  onDismiss={() => handleDismiss("inline-success")}
+                >
+                  Single line information with an action and dismiss option
+                </Banner>
+              )}
+            </div>
           </div>
         </div>
 

--- a/src/app/(main)/dashboard/design/page.tsx
+++ b/src/app/(main)/dashboard/design/page.tsx
@@ -1,20 +1,307 @@
+"use client";
+
+import { useState } from "react";
+import { Banner } from "@/components/ui/banner";
+
+const CodeBlock = ({ children, title }: { children: string; title: string }) => (
+  <div className="space-y-2">
+    <h4 className="text-xs font-medium text-muted-foreground uppercase tracking-wider">{title}</h4>
+    <pre className="bg-muted/50 rounded-lg p-3 text-xs overflow-x-auto">
+      <code>{children}</code>
+    </pre>
+  </div>
+);
+
+const BannerExample = ({
+  title,
+  code,
+  children,
+}: {
+  title: string;
+  code: string;
+  children: React.ReactNode;
+}) => (
+  <div className="space-y-4">
+    <h3 className="text-lg font-semibold">{title}</h3>
+    <div className="space-y-4">
+      <CodeBlock title="React Code" children={code} />
+      <div className="space-y-4">{children}</div>
+    </div>
+  </div>
+);
+
 export default function Page() {
+  const [dismissedBanners, setDismissedBanners] = useState<Set<string>>(new Set());
+
+  const handleDismiss = (id: string) => {
+    setDismissedBanners((prev) => new Set([...prev, id]));
+  };
+
+  const resetDismissed = () => {
+    setDismissedBanners(new Set());
+  };
+
   return (
-    <div className="@container/main flex flex-col gap-4 md:gap-6">
+    <div className="@container/main flex flex-col gap-6 md:gap-8">
       <div className="space-y-2">
         <h1 className="text-3xl font-bold tracking-tight">Design System</h1>
         <p className="text-muted-foreground">A comprehensive collection of reusable components and design patterns.</p>
       </div>
 
-      <div className="space-y-4">
-        <div>
-          <h2 className="text-xl font-semibold">Banners</h2>
-          <p className="text-muted-foreground text-sm">Banner components and variations will be displayed here.</p>
+      <div className="space-y-8">
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-xl font-semibold">Banners</h2>
+            <p className="text-muted-foreground text-sm">
+              Banner components for displaying important information with optional actions.
+            </p>
+          </div>
+          <button
+            onClick={resetDismissed}
+            className="text-xs text-muted-foreground hover:text-foreground underline"
+          >
+            Reset dismissed banners
+          </button>
         </div>
 
-        {/* Content will be added later */}
-        <div className="rounded-lg border border-dashed border-muted-foreground/25 p-8 text-center">
-          <p className="text-muted-foreground">Content coming soon...</p>
+        {/* Inline Variants */}
+        <BannerExample
+          title="Inline Banners"
+          code={`<Banner
+  layout="inline"
+  variant="info"
+  primaryAction={{ label: "Primary Action", onClick: () => {} }}
+  onDismiss={() => {}}
+>
+  Single line information with an action and dismiss option
+</Banner>`}
+        >
+          {!dismissedBanners.has("inline-info") && (
+            <Banner
+              layout="inline"
+              variant="info"
+              primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
+              onDismiss={() => handleDismiss("inline-info")}
+            >
+              Single line information with an action and dismiss option
+            </Banner>
+          )}
+
+          {!dismissedBanners.has("inline-neutral") && (
+            <Banner
+              layout="inline"
+              variant="info-neutral"
+              primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
+              onDismiss={() => handleDismiss("inline-neutral")}
+            >
+              Single line information with an action and dismiss option
+            </Banner>
+          )}
+
+          {!dismissedBanners.has("inline-error") && (
+            <Banner
+              layout="inline"
+              variant="error"
+              primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
+              onDismiss={() => handleDismiss("inline-error")}
+            >
+              Single line information with an action and dismiss option
+            </Banner>
+          )}
+
+          {!dismissedBanners.has("inline-warning") && (
+            <Banner
+              layout="inline"
+              variant="warning"
+              primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
+              onDismiss={() => handleDismiss("inline-warning")}
+            >
+              Single line information with an action and dismiss option
+            </Banner>
+          )}
+
+          {!dismissedBanners.has("inline-success") && (
+            <Banner
+              layout="inline"
+              variant="success"
+              primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
+              onDismiss={() => handleDismiss("inline-success")}
+            >
+              Single line information with an action and dismiss option
+            </Banner>
+          )}
+        </BannerExample>
+
+        {/* Block Variants */}
+        <BannerExample
+          title="Block Banners with Heading and Actions"
+          code={`<Banner
+  variant="info"
+  heading="At the moment, we are unable to identify the cause of the connection problem."
+  primaryAction={{ label: "Primary Action", onClick: () => {} }}
+  secondaryAction={{ label: "Secondary Action", onClick: () => {} }}
+  onDismiss={() => {}}
+>
+  Get help from the Builder community. This is the best place to get technical assistance from the team
+</Banner>`}
+        >
+          {!dismissedBanners.has("block-info") && (
+            <Banner
+              variant="info"
+              heading="At the moment, we are unable to identify the cause of the connection problem."
+              primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
+              secondaryAction={{ label: "Secondary Action", onClick: () => console.log("Secondary clicked") }}
+              onDismiss={() => handleDismiss("block-info")}
+            >
+              Get help from the Builder community. This is the best place to get technical assistance from the team
+            </Banner>
+          )}
+
+          {!dismissedBanners.has("block-neutral") && (
+            <Banner
+              variant="info-neutral"
+              heading="At the moment, we are unable to identify the cause of the connection problem."
+              primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
+              secondaryAction={{ label: "Secondary Action", onClick: () => console.log("Secondary clicked") }}
+              onDismiss={() => handleDismiss("block-neutral")}
+            >
+              Get help from the Builder community. This is the best place to get technical assistance from the team
+            </Banner>
+          )}
+
+          {!dismissedBanners.has("block-error") && (
+            <Banner
+              variant="error"
+              heading="At the moment, we are unable to identify the cause of the connection problem."
+              primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
+              secondaryAction={{ label: "Secondary Action", onClick: () => console.log("Secondary clicked") }}
+              onDismiss={() => handleDismiss("block-error")}
+            >
+              Get help from the Builder community. This is the best place to get technical assistance from the team
+            </Banner>
+          )}
+
+          {!dismissedBanners.has("block-warning") && (
+            <Banner
+              variant="warning"
+              heading="At the moment, we are unable to identify the cause of the connection problem."
+              primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
+              secondaryAction={{ label: "Secondary Action", onClick: () => console.log("Secondary clicked") }}
+              onDismiss={() => handleDismiss("block-warning")}
+            >
+              Get help from the Builder community. This is the best place to get technical assistance from the team
+            </Banner>
+          )}
+
+          {!dismissedBanners.has("block-success") && (
+            <Banner
+              variant="success"
+              heading="At the moment, we are unable to identify the cause of the connection problem."
+              primaryAction={{ label: "Primary Action", onClick: () => console.log("Primary clicked") }}
+              secondaryAction={{ label: "Secondary Action", onClick: () => console.log("Secondary clicked") }}
+              onDismiss={() => handleDismiss("block-success")}
+            >
+              Get help from the Builder community. This is the best place to get technical assistance from the team
+            </Banner>
+          )}
+        </BannerExample>
+
+        {/* Configuration Examples */}
+        <BannerExample
+          title="Configuration Options"
+          code={`// Without dismiss button
+<Banner variant="info" showDismiss={false}>
+  This banner cannot be dismissed
+</Banner>
+
+// Without icon
+<Banner variant="warning" showIcon={false}>
+  This banner has no icon
+</Banner>
+
+// Without actions
+<Banner variant="success" heading="Success!" onDismiss={() => {}}>
+  Operation completed successfully
+</Banner>
+
+// Custom className
+<Banner variant="error" className="border-2 border-dashed">
+  Custom styled banner
+</Banner>`}
+        >
+          <div className="space-y-4">
+            <Banner variant="info" showDismiss={false}>
+              This banner cannot be dismissed
+            </Banner>
+
+            <Banner variant="warning" showIcon={false} onDismiss={() => console.log("Dismissed")}>
+              This banner has no icon
+            </Banner>
+
+            <Banner variant="success" heading="Success!" onDismiss={() => console.log("Dismissed")}>
+              Operation completed successfully
+            </Banner>
+
+            <Banner variant="error" className="border-2 border-dashed" onDismiss={() => console.log("Dismissed")}>
+              Custom styled banner with dashed border
+            </Banner>
+          </div>
+        </BannerExample>
+
+        {/* Props Documentation */}
+        <div className="space-y-4">
+          <h3 className="text-lg font-semibold">Props</h3>
+          <div className="bg-muted/50 rounded-lg p-6">
+            <div className="space-y-4">
+              <div>
+                <h4 className="font-medium mb-2">BannerProps</h4>
+                <div className="space-y-2 text-sm">
+                  <div>
+                    <span className="font-mono bg-muted px-1.5 py-0.5 rounded">variant</span>
+                    <span className="text-muted-foreground ml-2">
+                      "info" | "info-neutral" | "error" | "warning" | "success"
+                    </span>
+                  </div>
+                  <div>
+                    <span className="font-mono bg-muted px-1.5 py-0.5 rounded">layout</span>
+                    <span className="text-muted-foreground ml-2">"inline" | "block"</span>
+                  </div>
+                  <div>
+                    <span className="font-mono bg-muted px-1.5 py-0.5 rounded">heading</span>
+                    <span className="text-muted-foreground ml-2">string (optional)</span>
+                  </div>
+                  <div>
+                    <span className="font-mono bg-muted px-1.5 py-0.5 rounded">children</span>
+                    <span className="text-muted-foreground ml-2">React.ReactNode</span>
+                  </div>
+                  <div>
+                    <span className="font-mono bg-muted px-1.5 py-0.5 rounded">onDismiss</span>
+                    <span className="text-muted-foreground ml-2">() => void (optional)</span>
+                  </div>
+                  <div>
+                    <span className="font-mono bg-muted px-1.5 py-0.5 rounded">primaryAction</span>
+                    <span className="text-muted-foreground ml-2">
+                      {`{ label: string; onClick: () => void }`} (optional)
+                    </span>
+                  </div>
+                  <div>
+                    <span className="font-mono bg-muted px-1.5 py-0.5 rounded">secondaryAction</span>
+                    <span className="text-muted-foreground ml-2">
+                      {`{ label: string; onClick: () => void }`} (optional)
+                    </span>
+                  </div>
+                  <div>
+                    <span className="font-mono bg-muted px-1.5 py-0.5 rounded">showDismiss</span>
+                    <span className="text-muted-foreground ml-2">boolean (default: true)</span>
+                  </div>
+                  <div>
+                    <span className="font-mono bg-muted px-1.5 py-0.5 rounded">showIcon</span>
+                    <span className="text-muted-foreground ml-2">boolean (default: true)</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/(main)/dashboard/design/page.tsx
+++ b/src/app/(main)/dashboard/design/page.tsx
@@ -219,7 +219,7 @@ export default function Page() {
   Get help from the Builder community. This is the best place to get technical assistance from the team
 </Banner>`}
             />
-            <div className="flex items-start">
+            <div className="flex items-start pt-6">
               {!dismissedBanners.has("block-info") && (
                 <Banner
                   variant="info"
@@ -248,7 +248,7 @@ export default function Page() {
   Get help from the Builder community. This is the best place to get technical assistance from the team
 </Banner>`}
             />
-            <div className="flex items-start">
+            <div className="flex items-start pt-6">
               {!dismissedBanners.has("block-neutral") && (
                 <Banner
                   variant="info-neutral"
@@ -277,7 +277,7 @@ export default function Page() {
   Get help from the Builder community. This is the best place to get technical assistance from the team
 </Banner>`}
             />
-            <div className="flex items-start">
+            <div className="flex items-start pt-6">
               {!dismissedBanners.has("block-error") && (
                 <Banner
                   variant="error"
@@ -306,7 +306,7 @@ export default function Page() {
   Get help from the Builder community. This is the best place to get technical assistance from the team
 </Banner>`}
             />
-            <div className="flex items-start">
+            <div className="flex items-start pt-6">
               {!dismissedBanners.has("block-warning") && (
                 <Banner
                   variant="warning"
@@ -335,7 +335,7 @@ export default function Page() {
   Get help from the Builder community. This is the best place to get technical assistance from the team
 </Banner>`}
             />
-            <div className="flex items-start">
+            <div className="flex items-start pt-6">
               {!dismissedBanners.has("block-success") && (
                 <Banner
                   variant="success"

--- a/src/app/(main)/dashboard/design/page.tsx
+++ b/src/app/(main)/dashboard/design/page.tsx
@@ -73,7 +73,7 @@ export default function Page() {
   Single line information with an action and dismiss option
 </Banner>`}
             />
-            <div className="flex items-center">
+            <div className="flex items-start pt-6">
               {!dismissedBanners.has("inline-info") && (
                 <Banner
                   layout="inline"

--- a/src/components/ui/banner.tsx
+++ b/src/components/ui/banner.tsx
@@ -1,0 +1,178 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+import { Info, AlertCircle, AlertTriangle, CheckCircle2, X, Plus } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+
+const bannerVariants = cva("flex items-start gap-3 rounded border p-3 transition-all", {
+  variants: {
+    variant: {
+      info: "border-blue-200 bg-blue-50 text-blue-900 dark:border-blue-800 dark:bg-blue-950 dark:text-blue-100",
+      "info-neutral":
+        "border-gray-200 bg-gray-50 text-gray-900 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100",
+      error: "border-red-200 bg-red-50 text-red-900 dark:border-red-800 dark:bg-red-950 dark:text-red-100",
+      warning:
+        "border-amber-200 bg-amber-50 text-amber-900 dark:border-amber-800 dark:bg-amber-950 dark:text-amber-100",
+      success:
+        "border-green-200 bg-green-50 text-green-900 dark:border-green-800 dark:bg-green-950 dark:text-green-100",
+    },
+    layout: {
+      inline: "items-center",
+      block: "items-start flex-col gap-2 sm:flex-row sm:gap-3",
+    },
+  },
+  defaultVariants: {
+    variant: "info",
+    layout: "block",
+  },
+});
+
+const iconVariants = cva("flex-shrink-0", {
+  variants: {
+    variant: {
+      info: "text-blue-600 dark:text-blue-400",
+      "info-neutral": "text-blue-600 dark:text-blue-400",
+      error: "text-red-600 dark:text-red-400",
+      warning: "text-amber-600 dark:text-amber-400",
+      success: "text-green-600 dark:text-green-400",
+    },
+  },
+  defaultVariants: {
+    variant: "info",
+  },
+});
+
+const getIcon = (variant: string) => {
+  switch (variant) {
+    case "info":
+    case "info-neutral":
+      return Info;
+    case "error":
+      return AlertCircle;
+    case "warning":
+      return AlertTriangle;
+    case "success":
+      return CheckCircle2;
+    default:
+      return Info;
+  }
+};
+
+export interface BannerProps extends React.HTMLAttributes<HTMLDivElement>, VariantProps<typeof bannerVariants> {
+  heading?: string;
+  children?: React.ReactNode;
+  onDismiss?: () => void;
+  primaryAction?: {
+    label: string;
+    onClick: () => void;
+  };
+  secondaryAction?: {
+    label: string;
+    onClick: () => void;
+  };
+  showDismiss?: boolean;
+  showIcon?: boolean;
+}
+
+const Banner = React.forwardRef<HTMLDivElement, BannerProps>(
+  (
+    {
+      className,
+      variant = "info",
+      layout = "block",
+      heading,
+      children,
+      onDismiss,
+      primaryAction,
+      secondaryAction,
+      showDismiss = true,
+      showIcon = true,
+      ...props
+    },
+    ref,
+  ) => {
+    const IconComponent = getIcon(variant || "info");
+
+    return (
+      <div ref={ref} className={cn(bannerVariants({ variant, layout }), className)} role="alert" {...props}>
+        {showIcon && <IconComponent className={cn(iconVariants({ variant }), "size-4 mt-0.5")} />}
+
+        <div className="flex-1 min-w-0">
+          {layout === "block" && heading && (
+            <div className="mb-1">
+              <h4 className="text-sm font-semibold leading-5">{heading}</h4>
+            </div>
+          )}
+
+          <div className={cn("text-sm leading-5", layout === "inline" ? "flex-1" : "space-y-3")}>
+            {children}
+
+            {(primaryAction || secondaryAction) && (
+              <div className="flex flex-wrap items-start gap-3">
+                {primaryAction && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={primaryAction.onClick}
+                    className={cn(
+                      "h-8 border-gray-300 bg-transparent px-3 py-1.5 text-xs hover:bg-gray-100 dark:border-gray-600 dark:hover:bg-gray-700",
+                      variant === "info" &&
+                        "border-blue-300 hover:bg-blue-100 dark:border-blue-600 dark:hover:bg-blue-800",
+                      variant === "error" &&
+                        "border-red-300 hover:bg-red-100 dark:border-red-600 dark:hover:bg-red-800",
+                      variant === "warning" &&
+                        "border-amber-300 hover:bg-amber-100 dark:border-amber-600 dark:hover:bg-amber-800",
+                      variant === "success" &&
+                        "border-green-300 hover:bg-green-100 dark:border-green-600 dark:hover:bg-green-800",
+                    )}
+                  >
+                    {primaryAction.label}
+                  </Button>
+                )}
+
+                {secondaryAction && (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={secondaryAction.onClick}
+                    className={cn(
+                      "h-8 px-3 py-1.5 text-xs hover:bg-transparent",
+                      variant === "info" &&
+                        "text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300",
+                      variant === "info-neutral" &&
+                        "text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300",
+                      variant === "error" &&
+                        "text-red-600 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300",
+                      variant === "warning" &&
+                        "text-amber-600 hover:text-amber-700 dark:text-amber-400 dark:hover:text-amber-300",
+                      variant === "success" &&
+                        "text-green-600 hover:text-green-700 dark:text-green-400 dark:hover:text-green-300",
+                    )}
+                  >
+                    <Plus className="mr-1 size-3" />
+                    {secondaryAction.label}
+                  </Button>
+                )}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {showDismiss && onDismiss && (
+          <button
+            onClick={onDismiss}
+            className="ml-auto flex-shrink-0 rounded p-1 hover:bg-black/5 dark:hover:bg-white/10"
+            aria-label="Dismiss"
+          >
+            <X className="size-4 text-gray-500 dark:text-gray-400" />
+          </button>
+        )}
+      </div>
+    );
+  },
+);
+
+Banner.displayName = "Banner";
+
+export { Banner, bannerVariants };

--- a/src/navigation/sidebar/sidebar-items.ts
+++ b/src/navigation/sidebar/sidebar-items.ts
@@ -94,7 +94,7 @@ export const sidebarItems: NavGroup[] = [
       },
       {
         title: "Calendar",
-        url: "/calendar",
+        url: "/dashboard/calendar",
         icon: Calendar,
       },
       {

--- a/src/navigation/sidebar/sidebar-items.ts
+++ b/src/navigation/sidebar/sidebar-items.ts
@@ -96,7 +96,6 @@ export const sidebarItems: NavGroup[] = [
         title: "Calendar",
         url: "/calendar",
         icon: Calendar,
-        comingSoon: true,
       },
       {
         title: "Kanban",

--- a/src/navigation/sidebar/sidebar-items.ts
+++ b/src/navigation/sidebar/sidebar-items.ts
@@ -15,6 +15,7 @@ import {
   Lock,
   Fingerprint,
   SquareArrowUpRight,
+  Palette,
   type LucideIcon,
 } from "lucide-react";
 

--- a/src/navigation/sidebar/sidebar-items.ts
+++ b/src/navigation/sidebar/sidebar-items.ts
@@ -67,6 +67,11 @@ export const sidebarItems: NavGroup[] = [
     label: "Pages",
     items: [
       {
+        title: "Design System",
+        url: "/dashboard/design",
+        icon: Palette,
+      },
+      {
         title: "Authentication",
         url: "/auth",
         icon: Fingerprint,


### PR DESCRIPTION
This PR adds a comprehensive design system page that showcases the Banner component with various configurations and examples.

Changes made:
- Created new design system page at `/dashboard/design`
- Added Banner UI component with multiple variants (info, error, warning, success, info-neutral)
- Implemented both inline and block layout options for banners
- Added support for dismissible banners with state management
- Included primary and secondary action buttons
- Added configuration options for showing/hiding icons and dismiss buttons
- Created interactive examples with code snippets
- Added API documentation for Banner component props
- Updated sidebar navigation to include Design System page with Palette icon

The Banner component supports:
- 5 color variants with proper theming
- Inline and block layouts
- Optional headings, actions, and dismiss functionality
- Customizable icon and dismiss button visibility
- Proper accessibility with role="alert"

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/8426495479a845af849eb305391806fc/zenith-field)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>8426495479a845af849eb305391806fc</projectId>-->
<!--<branchName>zenith-field</branchName>-->